### PR TITLE
feat: 自选抄送人后端功能实现

### DIFF
--- a/antflow-base/src/main/java/org/openoa/base/vo/BpmnNodeVo.java
+++ b/antflow-base/src/main/java/org/openoa/base/vo/BpmnNodeVo.java
@@ -175,6 +175,11 @@ public class BpmnNodeVo  implements Serializable {
      * @see MissingAssigneeProcessStragtegyEnum
      */
     private Integer missingAssigneeDealWay;
+
+	/**
+	 * 允许发起人自选抄送人
+	 */
+	private Integer ccSelfSelectFlag;
     public void setPrevId(List<String>prevId){
         this.prevId=prevId;
         if(!ObjectUtils.isEmpty(prevId)){

--- a/antflow-engine/src/main/java/org/openoa/engine/bpmnconf/confentity/BpmnNode.java
+++ b/antflow-engine/src/main/java/org/openoa/engine/bpmnconf/confentity/BpmnNode.java
@@ -131,6 +131,11 @@ public class BpmnNode {
     //whether current node is a parallel node 0 for no and 1 for yes
     @TableField("is_parallel")
     private Boolean isParallel;
+	/**
+	 * 0-无自选抄送人 1-允许发起人自选抄送人
+	 */
+	@TableField("cc_self_select_flag")
+	private Integer ccSelfSelectFlag;
 
 
 

--- a/antflow-engine/src/main/java/org/openoa/engine/bpmnconf/service/biz/SubmitProcessImpl.java
+++ b/antflow-engine/src/main/java/org/openoa/engine/bpmnconf/service/biz/SubmitProcessImpl.java
@@ -3,10 +3,12 @@ package org.openoa.engine.bpmnconf.service.biz;
 
 import com.google.common.collect.Maps;
 import lombok.extern.slf4j.Slf4j;
+import org.openoa.base.constant.enums.NodeTypeEnum;
 import org.openoa.base.interf.FormOperationAdaptor;
 import org.openoa.base.interf.ProcessOperationAdaptor;
 import org.openoa.base.constant.enums.ProcessOperationEnum;
 import org.openoa.base.util.SecurityUtils;
+import org.openoa.base.vo.BaseIdTranStruVo;
 import org.openoa.base.vo.BpmnStartConditionsVo;
 import org.openoa.base.exception.JiMuBizException;
 
@@ -15,13 +17,18 @@ import org.openoa.base.entity.BpmBusinessProcess;
 import org.openoa.base.entity.BpmProcessName;
 
 import org.openoa.base.vo.BusinessDataVo;
+import org.openoa.engine.bpmnconf.confentity.BpmnNode;
+import org.openoa.engine.bpmnconf.confentity.BpmnNodePersonnelConf;
+import org.openoa.engine.bpmnconf.confentity.BpmnNodePersonnelEmplConf;
+import org.openoa.engine.bpmnconf.service.impl.BpmnNodePersonnelConfServiceImpl;
+import org.openoa.engine.bpmnconf.service.impl.BpmnNodePersonnelEmplConfServiceImpl;
+import org.openoa.engine.bpmnconf.service.impl.BpmnNodeServiceImpl;
 import org.openoa.engine.factory.FormFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 
-import java.util.Arrays;
-import java.util.Date;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * process submit
@@ -38,6 +45,12 @@ public class SubmitProcessImpl implements ProcessOperationAdaptor {
 
     @Autowired
     private BpmProcessNameServiceImpl bpmProcessNameService;
+	@Autowired
+	private BpmnNodeServiceImpl bpmnNodeService;
+	@Autowired
+	private BpmnNodePersonnelConfServiceImpl bpmnNodePersonnelConfService;
+	@Autowired
+	private BpmnNodePersonnelEmplConfServiceImpl bpmnNodePersonnelEmplConfService;
 
     @Override
     public void doProcessButton(BusinessDataVo businessDataVo) {
@@ -91,11 +104,49 @@ public class SubmitProcessImpl implements ProcessOperationAdaptor {
                     .dataSourceId(vo.getDataSourceId())
                     .version(businessDataVo.getBpmnCode())
                     .build());
+	        // 提前将自选抄送人存到t_bpmn_node_personnel_empl_conf表, 下面的bpmnConfCommonService.startProcess里的bpmnConfService.detail代码会从t_bpmn_node_personnel_empl_conf里获取人员id和姓名,在bpmnRemoveConfFormatFactory.removeBpmnConf里写入empToForwardList，然后保存到bpm_process_forward实现抄送功能
+	        saveCcSelfFlag(businessDataVo.getApproversList(), applyName);
             //the process number is predictable
             businessDataVo.setProcessNumber(businessDataVo.getFormCode() + "_" + vo.getBusinessId());
         }
         bpmnConfCommonService.startProcess(businessDataVo.getBpmnCode(), bpmnStartConditionsVo);
     }
+
+	/**
+	 * 保存自选抄送人
+	 * @param nodeIdApproversMap 用户自选人信息 key：node_id value：自选人信息
+	 * @param userName 用户名
+	 */
+	private void saveCcSelfFlag(Map<String, List<BaseIdTranStruVo>> nodeIdApproversMap, String userName) {
+		if (!CollectionUtils.isEmpty(nodeIdApproversMap)) {
+			for (Map.Entry<String, List<BaseIdTranStruVo>> entry : nodeIdApproversMap.entrySet()) {
+				String nodeId = entry.getKey();
+				List<BaseIdTranStruVo> empIds = entry.getValue();
+				BpmnNode ccSelfSelectNode = bpmnNodeService.lambdaQuery()
+					.eq(BpmnNode::getNodeType, NodeTypeEnum.NODE_TYPE_COPY.getCode()).eq(BpmnNode::getId, nodeId).one();
+				if (Objects.isNull(ccSelfSelectNode)) {
+					continue;
+				}
+				Integer personnelConfId = Optional.ofNullable(
+						bpmnNodePersonnelConfService.lambdaQuery().select(BpmnNodePersonnelConf::getId).eq(BpmnNodePersonnelConf::getBpmnNodeId, ccSelfSelectNode.getId()).one())
+					.map(BpmnNodePersonnelConf::getId).orElse(null);
+				if (Objects.nonNull(personnelConfId) && !CollectionUtils.isEmpty(empIds)) {
+					List<BpmnNodePersonnelEmplConf> pceEntityList = new ArrayList<>();
+					empIds.forEach(empId -> {
+						BpmnNodePersonnelEmplConf bpmnNodePersonnelEmplConf = new BpmnNodePersonnelEmplConf();
+						bpmnNodePersonnelEmplConf.setBpmnNodePersonneId(personnelConfId);
+						bpmnNodePersonnelEmplConf.setEmplId(empId.getId());
+						bpmnNodePersonnelEmplConf.setEmplName(empId.getName());
+						bpmnNodePersonnelEmplConf.setIsDel(0);
+						bpmnNodePersonnelEmplConf.setCreateUser(userName);
+						bpmnNodePersonnelEmplConf.setUpdateUser(userName);
+						pceEntityList.add(bpmnNodePersonnelEmplConf);
+					});
+					bpmnNodePersonnelEmplConfService.saveBatch(pceEntityList);
+				}
+			}
+		}
+	}
 
     @Override
     public void setSupportBusinessObjects() {

--- a/antflow-engine/src/main/java/org/openoa/engine/bpmnconf/service/impl/BpmnConfServiceImpl.java
+++ b/antflow-engine/src/main/java/org/openoa/engine/bpmnconf/service/impl/BpmnConfServiceImpl.java
@@ -142,6 +142,9 @@ public class BpmnConfServiceImpl extends ServiceImpl<BpmnConfMapper, BpmnConf> {
             if(NodeTypeEnum.NODE_TYPE_COPY.getCode().equals(bpmnNodeVo.getNodeType())){
                 hasCopy=BpmnConfFlagsEnum.HAS_COPY.getCode();;
             }
+	        if (Objects.equals(bpmnNodeVo.getCcSelfSelectFlag(), 1)) {
+		        bpmnNodeVo.setNodeProperty(NodePropertyEnum.NODE_PROPERTY_CUSTOMIZE.getCode());
+	        }
             bpmnNodeVo.setIsOutSideProcess(isOutSideProcess);
             bpmnNodeVo.setIsLowCodeFlow(isLowCodeFlow);
 


### PR DESCRIPTION
### 自选抄送人的后端实现
##### 前提：
t_bpmn_node表新增一个字段，代表是否为自选抄送人节点
```sql
-- 增加自选抄送人字段
alter table antflow.t_bpmn_node add cc_self_select_flag tinyint default 0 not null comment '自选抄送人' after is_deduplication;
```
##### 思路：
1. 流程设计时，将前端传来的saveCcSelfFlag参数保存到t_bpmn_node表，=1表示当前节点是自选抄送人节点
2. 流程发起前时，在SubmitProcessImpl类中的bpmnConfCommonService.startProcess前，需要将抄送人信息保存到t_bpmn_node_personnel_empl_conf表
3. BpmnConfCommonServiceImpl#startProcess里在bpmnConfService.detail(bpmnCode)的时候就会将保存的抄送人信息从t_bpmn_node_personnel_empl_conf表查出来，
4. 在bpmnRemoveConfFormatFactory.removeBpmnConf里写入empToForwardList
5. 最后，保存到bpm_process_forward实现抄送功能
